### PR TITLE
fix(build): packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ Issues = "https://github.com/sumup/sumup-py/issues"
 "Source Code" = "https://github.com/sumup/sumup-py"
 
 [tool.setuptools]
-py-modules = ["sumup"]
+packages = ["sumup"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
https://github.com/sumup/sumup-py/pull/33 broke packaging by accidentally not including the source files. Here we fix it.