### PR TITLE
fix: for build using setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools"]
-build-backend = "setuptools.build_meta
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "sumup"
@@ -17,6 +17,7 @@ dependencies = [
     "ty==0.0.5",
     "typing-extensions>=4.13.2",
 ]
+license-files = ["LICENSE"]
 classifiers = [
     "Typing :: Typed",
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
If you want to create an RPM from the tar.gz archive, e.g. for Fedora, the pyproject.toml must be syntactically correct.
The following errors have been fixed:
- Name of the build system was missing
- If a ‘LICENSE’ file is present, the options licence and licence-files must not be set.