### PR TITLE
fix: The license-files tag conflict with the auto embedded LICENSE file.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "ty==0.0.7",
     "typing-extensions>=4.13.2",
 ]
-license-files = ["LICENSE"]
 classifiers = [
     "Typing :: Typed",
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Without the patch the build fails with:
```
Handling setuptools from build-system.requires
Requirement satisfied: setuptools
   (installed: setuptools 74.1.3)
Traceback (most recent call last):
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 743, in main
    generate_requires(
    ~~~~~~~~~~~~~~~~~^
        include_runtime=args.runtime,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<11 lines>...
        config_settings=parse_config_settings_args(args.config_settings),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 626, in generate_requires
    generate_build_requirements(backend, requirements)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 313, in generate_build_requirements
    new_reqs = get_requires(requirements.config_settings)
  File "/usr/lib/python3.13/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
    self.run_setup()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/setuptools/build_meta.py", line 318, in run_setup
    exec(code, locals())
    ~~~~^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.13/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 158, in setup
    dist.parse_config_files()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/setuptools/dist.py", line 608, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/setuptools/config/pyprojecttoml.py", line 71, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
  File "/usr/lib/python3.13/site-packages/setuptools/config/pyprojecttoml.py", line 139, in read_configuration
    validate(subset, filepath)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/setuptools/config/pyprojecttoml.py", line 60, in validate
    raise ValueError(f"{error}\n{summary}") from None
ValueError: invalid pyproject.toml config: `project`.
configuration error: `project` must not contain {'license-files'} properties
```
Because the LICENSE file is includes by default.