### PR TITLE
Rename parameter 'id' to 'transaction_id' in get method

### DIFF
--- a/sumup/receipts/resource.py
+++ b/sumup/receipts/resource.py
@@ -44,7 +44,7 @@ class ReceiptsResource(Resource):
 
     def get(
         self,
-        id: str,
+        transaction_id: str,
         *,
         mid: str,
         tx_event_id: typing.Union[int, NotGivenType] = NOT_GIVEN,


### PR DESCRIPTION
Just for more clarity this is said in the documentation but its just better ergonomics while developing